### PR TITLE
Look up tags individually

### DIFF
--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -127,20 +127,19 @@ renderLarceny ctxt name =
        _ -> return Nothing
 
 fauxRequester :: Maybe (MVar [Text]) -> Text -> [(Text, Text)] -> IO Text
-fauxRequester _  "/tags" [] =
+fauxRequester _ "/tags" [("slug", "home-featured")] =
   return $ enc [object [ "id" .= (177 :: Int)
                        , "slug" .= ("home-featured" :: Text)
-                       ]
-               ,object [ "id" .= (160 :: Int)
+                       ]]
+fauxRequester _ "/tags" [("slug", "featured-global")] =
+  return $ enc [object [ "id" .= (160 :: Int)
                        , "slug" .= ("featured-global" :: Text)
-                       ]
-               ]
-fauxRequester _ "/categories" [] =
-          return $ enc [object [ "id" .= (159 :: Int)
-                               , "slug" .= ("bookmarx" :: Text)
-                               , "meta" .= object ["links" .= object ["self" .= ("/159" :: Text)]]
-                               ]
-                       ]
+                       ]]
+fauxRequester _ "/categories" [("slug", "bookmarx")] =
+  return $ enc [object [ "id" .= (159 :: Int)
+                       , "slug" .= ("bookmarx" :: Text)
+                       , "meta" .= object ["links" .= object ["self" .= ("/159" :: Text)]]
+                       ] ]
 fauxRequester _ "/pages" [("slug", "a-first-page")] =
   return $ enc [page1]
 fauxRequester mRecord rqPath rqParams = do

--- a/src/Web/Offset/Cache.hs
+++ b/src/Web/Offset/Cache.hs
@@ -96,4 +96,5 @@ formatKey = format
         format (PageKey s) = ns "page:" <> s
         format (AuthorKey n) = ns "author:" <> tshow n
         format (TaxDictKey t) = ns "tax_dict:" <> t
+        format (TaxSlugKey tn ts) = ns "tax_slug:" <> tn <> ":" <> ts
         ns k = "wordpress:" <> k

--- a/src/Web/Offset/Internal.hs
+++ b/src/Web/Offset/Internal.hs
@@ -26,6 +26,7 @@ wpRequestInt runHTTP endpt key =
    PostKey i ->                   req ("/posts/" <> tshow i) []
    PageKey s ->                   req "/pages" [("slug", s)]
    AuthorKey i ->                 req ("/users/" <> tshow i) []
+   TaxSlugKey tName tSlug ->      req ("/" <> tName) [("slug", tSlug)]
   where req path = unRequester runHTTP (endpt <> path)
 
 buildParams :: WPKey -> [(Text, Text)]

--- a/src/Web/Offset/Queries.hs
+++ b/src/Web/Offset/Queries.hs
@@ -46,12 +46,14 @@ lookupSpecId wp@Wordpress{..} taxName spec =
       resp <- cachingGetErrorInt cacheSettings key
       case decodeJson resp of
         Nothing -> do
-          wpLogger $ "Unparseable JSON in lookupSpecId for: " <> tshow spec
+          wpLogger $ "Unparseable JSON in lookupSpecId for: " <> tshow spec <>
+                     " response: " <> resp
           return Nothing
         Just [] ->  do
-          wpLogger $ "No id found for lookupSpecId for: " <> tshow spec
+          wpLogger $ "No id found in lookupSpecId for: " <> tshow spec
           return Nothing
         Just [taxRes] -> return $ Just taxRes
         Just (x:xs) ->  do
-          wpLogger $ "JSON response for lookupSpecId: " <> tshow spec <> " contains multiple results: " <> resp
+          wpLogger $ "JSON response in lookupSpecId for: " <> tshow spec
+                     <> " contains multiple results: " <> resp
           return Nothing

--- a/src/Web/Offset/Queries.hs
+++ b/src/Web/Offset/Queries.hs
@@ -20,14 +20,6 @@ lookupTaxDict key@(TaxDictKey resName) wp@Wordpress{..} =
                      terror $ "Unparsable JSON: " <> resp
        Just res -> return (resName, getSpecId $ TaxDict res resName)
 
-lookupTaxSlug :: WPKey -> Wordpress b -> IO (Int -> Text)
-lookupTaxSlug key@(TaxDictKey resName) wp@Wordpress{..} =
-  do resp <- cachingGetErrorInt (cacheInternals { wpCacheSet = wpCacheSetInt (runRedis cacheInternals) (CacheSeconds (12 * 60 * 60))}) key
-     case decodeJson resp of
-       Nothing -> do wpExpirePostInt (runRedis cacheInternals) key
-                     terror $ "Unparsable JSON: " <> resp
-       Just res -> return (getTaxSlug $ TaxDict res resName)
-
 getSpecId :: TaxDict -> TaxSpec -> TaxSpecId
 getSpecId taxDict spec =
   case spec of
@@ -40,8 +32,26 @@ getSpecId taxDict spec =
        [] -> terror $ "Couldn't find " <> desc <> ": " <> slug
        (TaxRes (i,_):_) -> i
 
-getTaxSlug :: TaxDict -> Int -> Text
-getTaxSlug (TaxDict{..}) taxId =
-  case filter (\(TaxRes (i, _)) -> i == taxId) dict of
-    [] -> terror $ "Couldn't find " <> desc <> " with id: " <> tshow taxId
-    (TaxRes (_,s):_) -> s
+lookupSpecId :: Wordpress b -> TaxonomyName -> TaxSpec -> IO (Maybe TaxSpecId)
+lookupSpecId wp@Wordpress{..} taxName spec =
+  case spec of
+   TaxPlus slug -> (fmap . fmap) (\(TaxRes (i, _)) -> TaxPlusId i) (idFor taxName slug)
+   TaxMinus slug -> (fmap . fmap) (\(TaxRes (i, _)) -> TaxMinusId i) (idFor taxName slug)
+  where
+    idFor :: Text -> Text -> IO (Maybe TaxRes)
+    idFor taxName slug = do
+      let key = TaxSlugKey taxName slug
+      let cacheSettings = cacheInternals { wpCacheSet = wpCacheSetInt (runRedis cacheInternals)
+                                                                      (CacheSeconds (12 * 60 * 60)) }
+      resp <- cachingGetErrorInt cacheSettings key
+      case decodeJson resp of
+        Nothing -> do
+          wpLogger $ "Unparseable JSON in lookupSpecId for: " <> tshow spec
+          return Nothing
+        Just [] ->  do
+          wpLogger $ "No id found for lookupSpecId for: " <> tshow spec
+          return Nothing
+        Just [taxRes] -> return $ Just taxRes
+        Just (x:xs) ->  do
+          wpLogger $ "JSON response for lookupSpecId: " <> tshow spec <> " contains multiple results: " <> resp
+          return Nothing

--- a/src/Web/Offset/Types.hs
+++ b/src/Web/Offset/Types.hs
@@ -104,6 +104,7 @@ data WPKey = PostKey Int
            | PageKey Text
            | AuthorKey Int
            | TaxDictKey Text
+           | TaxSlugKey TaxonomyName Slug
            deriving (Eq, Show, Ord)
 
 tagChars :: String


### PR DESCRIPTION
WordPress API pages the tag index, so tags past the first 10 were not fetched! Now all tags are fetched.