### PR TITLE
Gracefully handle 404s and other HTTP errors

### DIFF
--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -129,34 +129,34 @@ renderLarceny ctxt name =
          return $ Just rendered
        _ -> return Nothing
 
-fauxRequester :: Maybe (MVar [Text]) -> Text -> [(Text, Text)] -> IO Text
+fauxRequester :: Maybe (MVar [Text]) -> Text -> [(Text, Text)] -> IO (Either StatusCode Text)
 fauxRequester _ "/wp/v2/tags" [("slug", "home-featured")] =
-  return $ enc [object [ "id" .= (177 :: Int)
+  return $ Right $ enc [object [ "id" .= (177 :: Int)
                        , "slug" .= ("home-featured" :: Text)
                        ]]
 fauxRequester _ "/wp/v2/tags" [("slug", "featured-global")] =
-  return $ enc [object [ "id" .= (160 :: Int)
+  return $ Right $ enc [object [ "id" .= (160 :: Int)
                        , "slug" .= ("featured-global" :: Text)
                        ]]
 fauxRequester _ "/wp/v2/categories" [("slug", "bookmarx")] =
-  return $ enc [object [ "id" .= (159 :: Int)
+  return $ Right $ enc [object [ "id" .= (159 :: Int)
                        , "slug" .= ("bookmarx" :: Text)
                        , "meta" .= object ["links" .= object ["self" .= ("/159" :: Text)]]
                        ] ]
 fauxRequester _ "/jacobin/featured-content/editors-picks" [] =
-  return $ enc [object [ "post_date" .= ("2013-04-26 10:11:52" :: Text)
+  return $ Right $ enc [object [ "post_date" .= ("2013-04-26 10:11:52" :: Text)
                        , "date" .= ("2014-04-26 10:11:52" :: Text)
                        , "post_date_gmt" .= ("2015-04-26 15:11:52" :: Text)
                        ]]
 fauxRequester _ "/wp/v2/pages" [("slug", "a-first-page")] =
-  return $ enc [page1]
+  return $ Right $ enc [page1]
 fauxRequester _ "/dev/null" [] =
-  return $ enc [object ["this_is_null" .= Null]]
+  return $ Right $ enc [object ["this_is_null" .= Null]]
 fauxRequester mRecord rqPath rqParams = do
   case mRecord of
     Just record -> modifyMVar_ record $ return . (<> [mkUrlUnescape rqPath rqParams])
     Nothing -> return ()
-  return $ enc [article1]
+  return $ Right $ enc [article1]
   where mkUrlUnescape url params =
              url <> "?"
           <> T.intercalate "&" (map (\(k, v) -> k <> "=" <> v) params)
@@ -179,7 +179,7 @@ initFauxRequestNoCache =
   initializer (Right $ Requester (fauxRequester Nothing)) NoCache ""
 
 initNoRequestWithCache =
-  initializer (Right $ Requester (\_ _ -> return "" )) (CacheSeconds 60) ""
+  initializer (Right $ Requester (\_ _ -> return (Right "") )) (CacheSeconds 60) ""
 
 ----------------------------------------------------------
 -- Section 2: Test suite against application.           --

--- a/src/Web/Offset/HTTP.hs
+++ b/src/Web/Offset/HTTP.hs
@@ -22,6 +22,7 @@ wreqRequester :: (Text -> IO ())
 wreqRequester logger user passw =
   Requester $ \u ps -> do let opts = W.defaults & W.params .~ ps
                                                 & W.auth ?~ W.basicAuth user' pass'
+                                                & W.checkStatus ?~ (\__ _ _ -> Nothing)
                           logger $ "wreq: " <> u <> " with params: " <>
                             (T.intercalate "&" . map (\(a,b) -> a <> "=" <> b) $ ps)
                           r <- W.getWith opts (T.unpack u)

--- a/src/Web/Offset/HTTP.hs
+++ b/src/Web/Offset/HTTP.hs
@@ -11,7 +11,9 @@ import qualified Data.Text.Lazy          as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Network.Wreq            as W
 
-newtype Requester = Requester { unRequester :: Text -> [(Text, Text)] -> IO Text }
+newtype Requester = Requester { unRequester :: Text
+                                            -> [(Text, Text)]
+                                            -> IO (Either Int Text) }
 
 wreqRequester :: (Text -> IO ())
               -> Text
@@ -23,6 +25,8 @@ wreqRequester logger user passw =
                           logger $ "wreq: " <> u <> " with params: " <>
                             (T.intercalate "&" . map (\(a,b) -> a <> "=" <> b) $ ps)
                           r <- W.getWith opts (T.unpack u)
-                          return $ TL.toStrict . TL.decodeUtf8 $ r ^. W.responseBody
+                          case r ^. W.responseStatus ^. W.statusCode of
+                            200 -> return $ Right $ TL.toStrict . TL.decodeUtf8 $ r ^. W.responseBody
+                            n -> return $ Left n
   where user' = T.encodeUtf8 user
         pass' = T.encodeUtf8 passw

--- a/src/Web/Offset/Internal.hs
+++ b/src/Web/Offset/Internal.hs
@@ -17,7 +17,7 @@ import           Web.Offset.HTTP
 import           Web.Offset.Types
 import           Web.Offset.Utils
 
-wpRequestInt :: Requester -> Text -> WPKey -> IO Text
+wpRequestInt :: Requester -> Text -> WPKey -> IO (Either StatusCode Text)
 wpRequestInt runHTTP endpt key =
   case key of
    TaxDictKey resName ->          req (defaultEndpoint <> "/" <> resName) []

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -77,7 +77,7 @@ wpCustomFill wp@Wordpress{..} =
                                    <> " when querying \"" <> endpoint <> "\"."
                  liftIO $ wpLogger notification
                  return $ "<!-- " <> notification <> " -->"
-               Right (Just (json :: Value)) -> do
+               Right (Just (json :: Value)) ->
                  unFill (jsonToFill json) attrs (path, tpl) lib
                Right Nothing -> do
                  let notification = "Unable to decode JSON for endpoint \"" <> endpoint

--- a/src/Web/Offset/Utils.hs
+++ b/src/Web/Offset/Utils.hs
@@ -39,21 +39,6 @@ decodeJson = decode
 performOnJust :: (o -> IO ()) -> Maybe o -> IO ()
 performOnJust = maybe (return ())
 
-retryUnless :: IO (Maybe a) -> IO a
-retryUnless action =
-  do ma <- action
-     case ma of
-       Just r -> return r
-       Nothing -> do CC.threadDelay 100000
-                     retryUnless action
-
-errorUnless :: Text -> IO (Maybe a) -> IO a
-errorUnless msg action =
-  do ma <- action
-     case ma of
-      Just a -> return a
-      Nothing -> error $ T.unpack msg
-
 concurrently :: [IO a] -> IO [a]
 concurrently [] = return []
 concurrently [a] =


### PR DESCRIPTION
Now logs 404s and 500s and displays an HTML comment instead of just
blowing up with an error.