### PR TITLE
Users can specify a date format for dates

### DIFF
--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -264,13 +264,26 @@ larcenyFillTests = do
   describe "<wpCustom>" $
     it "should render an HTML comment if JSON field is null" $
       "<wpCustom endpoint=\"dev/null\"><wpThisIsNull /></wpCustom>" `shouldRender` "<!-- JSON field found, but value is null. -->"
-  describe "<wpCustomDate>" $
+  describe "<wpCustomDate>" $ do
     it "should parse a date field with the format string it's given" $
       "<wpCustom endpoint=\"jacobin/featured-content/editors-picks\" > \
-      \   <wpCustomDate date=\"${wpPostDate}\" format=\"%Y-%m-%d %H:%M:%S\"> \
+      \   <wpCustomDate date=\"${wpPostDate}\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
       \     <wpDay />~<wpMonth />~<wpYear /> \
       \   </wpCustomDate> \
-      \ </wpCustom>" `shouldRender` "26~4~2013"
+      \ </wpCustom>" `shouldRender` "26~04~2013"
+    it "should format a date field with the format strings it's given" $
+      "<wpCustom endpoint=\"jacobin/featured-content/editors-picks\" > \
+      \   <wpCustomDate date=\"${wpPostDate}\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
+      \     <wpMonth format_out=\"%B\"/> <wpDay format_out=\"%-d\"/>, <wpYear /> \
+      \   </wpCustomDate> \
+      \ </wpCustom>" `shouldRender` "April 26, 2013"
+    it "should use default WordPress date format if none specified" $
+      "<wpCustom endpoint=\"jacobin/featured-content/editors-picks\" > \
+      \   <wpCustomDate date=\"${wpPostDate}\"> \
+      \     <wpDay />~<wpMonth />~<wpYear /> \
+      \   </wpCustomDate> \
+      \ </wpCustom>" `shouldRender` "26~04~2013"
+
 
 
 -- Caching tests

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -266,23 +266,17 @@ larcenyFillTests = do
       "<wpCustom endpoint=\"dev/null\"><wpThisIsNull /></wpCustom>" `shouldRender` "<!-- JSON field found, but value is null. -->"
   describe "<wpCustomDate>" $ do
     it "should parse a date field with the format string it's given" $
-      "<wpCustom endpoint=\"jacobin/featured-content/editors-picks\" > \
-      \   <wpCustomDate date=\"${wpPostDate}\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
-      \     <wpDay />~<wpMonth />~<wpYear /> \
-      \   </wpCustomDate> \
-      \ </wpCustom>" `shouldRender` "26~04~2013"
+      "<wpCustomDate date=\"2013-04-26 10:11:52\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
+      \   <wpDay />~<wpMonth />~<wpYear /> \
+      \ </wpCustomDate>" `shouldRender` "26~04~2013"
     it "should format a date field with the format strings it's given" $
-      "<wpCustom endpoint=\"jacobin/featured-content/editors-picks\" > \
-      \   <wpCustomDate date=\"${wpPostDate}\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
-      \     <wpMonth format_out=\"%B\"/> <wpDay format_out=\"%-d\"/>, <wpYear /> \
-      \   </wpCustomDate> \
-      \ </wpCustom>" `shouldRender` "April 26, 2013"
+      "<wpCustomDate date=\"2013-04-26 10:11:52\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
+      \   <wpMonth format_out=\"%B\"/> <wpDay format_out=\"%-d\"/>, <wpYear /> \
+      \ </wpCustomDate>" `shouldRender` "April 26, 2013"
     it "should use default WordPress date format if none specified" $
-      "<wpCustom endpoint=\"jacobin/featured-content/editors-picks\" > \
-      \   <wpCustomDate date=\"${wpPostDate}\"> \
-      \     <wpDay />~<wpMonth />~<wpYear /> \
-      \   </wpCustomDate> \
-      \ </wpCustom>" `shouldRender` "26~04~2013"
+      "<wpCustomDate date=\"2013-04-26 10:11:52\"> \
+      \    <wpDay />~<wpMonth />~<wpYear /> \
+      \ </wpCustomDate>" `shouldRender` "26~04~2013"
 
 
 

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -277,6 +277,10 @@ larcenyFillTests = do
       "<wpCustomDate date=\"2013-04-26 10:11:52\"> \
       \    <wpDay />~<wpMonth />~<wpYear /> \
       \ </wpCustomDate>" `shouldRender` "26~04~2013"
+    it "should allow formatting the whole date in a single tag" $
+      "<wpCustomDate date=\"2013-04-26 10:11:52\"> \
+      \    <wpDate /> \
+      \ </wpCustomDate>" `shouldRender` "04/26/13"
 
 
 

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -65,7 +65,8 @@ wpCustomDateFill =
           case parsedDate of
               Just d -> let dateSubs = subs [ ("wpYear", datePartFill "%0Y" d)
                                             , ("wpMonth", datePartFill "%m" d)
-                                            , ("wpDay", datePartFill "%d" d)] in
+                                            , ("wpDay", datePartFill "%d" d)
+                                            , ("wpDate", datePartFill "%D" d) ] in
                         fillChildrenWith dateSubs
               Nothing -> textFill $ "<!-- Unable to parse date: " <> date <> " -->"
         datePartFill defaultFormat date =

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -51,10 +51,10 @@ wordpressSubs wp extraFields getURI wpLens =
         , ("wpNoPostDuplicates", wpNoPostDuplicatesFill wpLens)
         , ("wp", wpPrefetch wp extraFields getURI wpLens)
         , ("wpCustom", wpCustomFill wp)
-        , ("wpCustomDate", wpCustomDateFill wp)]
+        , ("wpCustomDate", wpCustomDateFill)]
 
-wpCustomDateFill :: Wordpress b -> Fill s
-wpCustomDateFill wp@Wordpress{..} =
+wpCustomDateFill :: Fill s
+wpCustomDateFill =
   useAttrs (a "wp_format" % a "date") customDateFill
   where customDateFill mWPFormat date =
           let wpFormat = fromMaybe "%Y-%m-%d %H:%M:%S" mWPFormat


### PR DESCRIPTION
I changed the "format" attribute name to "wp_format", because it specifies the format you expect the WordPress date to be in. Since WordPress just has a default date type, I also made this an optional field.

Most of the time, we want days to be zero-padded to two characters, so I made that the default.

I also made the formats of each date field configurable using the formatDate function from the same library as our date parsing function. This allows users to do stuff like show the name of the month really easily!! It's just another format string.