### PR TITLE
Add format to wpDate in wpPosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog
+
+## February 9 2017
+
+ * Add "format" attribute to `wpDate` in `wpPosts`
+ * Change "format_out" to just "format" in `wpCustomDate`
+
+## Old changelog
+
 * 0.1.1.2 - Add missing Misc module for test suite, expose modules for test suite.
 * 0.1.1.1 - Update for GHC 7.10.
 * 0.1.1.0 - Initial release.

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -68,16 +68,19 @@ enc a = TL.toStrict . TL.decodeUtf8 . encode $ a
 
 article1 :: Value
 article1 = object [ "id" .= (1 :: Int)
+                  , "date" .= ("2014-10-20T07:00:00" :: Text)
                   , "title" .= object ["rendered" .= ("Foo bar" :: Text)]
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
                   ]
 
 article2 = object [ "id" .= (2 :: Int)
+                  , "date" .= ("2014-10-20T07:00:00" :: Text)
                   , "title" .= object ["rendered" .= ("The post" :: Text)]
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
                   ]
 
 page1 = object [ "id" .= (3 :: Int)
+               , "date" .= ("2014-10-20T07:00:00" :: Text)
                , "title" .= object ["rendered" .= ("Page foo" :: Text)]
                , "content" .= object ["rendered" .= ("<b>rendered</b> page content" :: Text)]
                ]

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -58,11 +58,17 @@ main :: IO ()
 main = runTests
 
 larcenyFillTests = do
-  describe "<wpPosts>" $
+  describe "<wpPosts>" $ do
     it "should show the title, id, and excerpt" $ do
       "<wpPosts><wpTitle/></wpPosts>" `shouldRender` "Foo bar"
       "<wpPosts><wpId/></wpPosts>" `shouldRender` "1"
       "<wpPosts><wpExcerpt/></wpPosts>" `shouldRender` "summary"
+    it "should allow formating of dates" $
+      "<wpPosts> \
+      \  <wpDate> \
+      \    <wpMonth format=\"%B\"/> <wpDay format=\"%-d\"/>, <wpYear /> \
+      \  </wpDate> \
+      \</wpPosts>" `shouldRender` "October 20, 2014"
   describe "<wpPage>" $
     it "should show the content" $
       "<wpPage name=a-first-page />" `shouldRender` "<b>rendered</b> page content"
@@ -109,7 +115,7 @@ larcenyFillTests = do
       \ </wpCustomDate>" `shouldRender` "26~04~2013"
     it "should format a date field with the format strings it's given" $
       "<wpCustomDate date=\"2013-04-26 10:11:52\" wp_format=\"%Y-%m-%d %H:%M:%S\"> \
-      \   <wpMonth format_out=\"%B\"/> <wpDay format_out=\"%-d\"/>, <wpYear /> \
+      \   <wpMonth format=\"%B\"/> <wpDay format=\"%-d\"/>, <wpYear /> \
       \ </wpCustomDate>" `shouldRender` "April 26, 2013"
     it "should use default WordPress date format if none specified" $
       "<wpCustomDate date=\"2013-04-26 10:11:52\"> \
@@ -117,7 +123,7 @@ larcenyFillTests = do
       \ </wpCustomDate>" `shouldRender` "26~04~2013"
     it "should allow formatting the whole date in a single tag" $
       "<wpCustomDate date=\"2013-04-26 10:11:52\"> \
-      \    <wpDate /> \
+      \    <wpFullDate /> \
       \ </wpCustomDate>" `shouldRender` "04/26/13"
 
 -- Caching tests

--- a/src/Web/Offset/Field.hs
+++ b/src/Web/Offset/Field.hs
@@ -55,7 +55,7 @@ postFields = [F "id"
              ,F "type"
              ,F "author"
              ,C "content" ["content", "rendered"]
-             ,P "date" dateSplice
+             ,P "date" wpDateFill
              ,F "slug"
              ,C "excerpt" ["excerpt", "rendered"]
              ,N "custom_fields" [F "test"]
@@ -71,12 +71,21 @@ postFields = [F "id"
                         ,M "post_tag" [F "id", F "name", F "slug", F "count"]]
              ]
 
-dateSplice :: Text -> Fill s
-dateSplice date =
-  let (y,m,d) = parseDate date in
-  fillChildrenWith $ subs [ ("wpYear", textFill y)
-                          , ("wpMonth", textFill m)
-                          , ("wpDay", textFill d)]
-  where parseDate :: Text -> (Text,Text,Text)
-        parseDate = tuplify . T.splitOn "-" . T.takeWhile (/= 'T')
-        tuplify (y:m:d:_) = (y,m,d)
+wpDateFill :: Text -> Fill s
+wpDateFill date =
+  let wpFormat = "%Y-%m-%dT%H:%M:%S"
+      parsedDate = trace (T.unpack ("Date: " <> date)) $ parseTimeM False
+                    defaultTimeLocale
+                    (T.unpack wpFormat)
+                    (T.unpack date) :: Maybe UTCTime in
+  case parsedDate of
+    Just d -> let dateSubs = subs [ ("wpYear",     datePartFill "%0Y" d)
+                                  , ("wpMonth",    datePartFill "%m"  d)
+                                  , ("wpDay",      datePartFill "%d"  d)
+                                  , ("wpFullDate", datePartFill "%D"  d) ] in
+                fillChildrenWith dateSubs
+    Nothing -> textFill $ "<!-- Unable to parse date: " <> date <> " -->"
+  where datePartFill defaultFormat date =
+          useAttrs (a "format") $ \mf ->
+                   let f = fromMaybe defaultFormat mf in
+                   textFill $ T.pack $ formatTime defaultTimeLocale (T.unpack f) date

--- a/src/Web/Offset/Field.hs
+++ b/src/Web/Offset/Field.hs
@@ -5,9 +5,12 @@ module Web.Offset.Field where
 
 import           Control.Applicative ((<$>))
 import           Control.Monad.State
+import           Data.Maybe          (fromMaybe)
 import           Data.Monoid         ((<>))
 import           Data.Text           (Text)
 import qualified Data.Text           as T
+import           Data.Time.Clock     (UTCTime)
+import           Data.Time.Format    (defaultTimeLocale, formatTime, parseTimeM)
 import           Web.Larceny
 
 -- TODO(dbp 2014-10-14): date should be parsed and nested.
@@ -74,7 +77,7 @@ postFields = [F "id"
 wpDateFill :: Text -> Fill s
 wpDateFill date =
   let wpFormat = "%Y-%m-%dT%H:%M:%S"
-      parsedDate = trace (T.unpack ("Date: " <> date)) $ parseTimeM False
+      parsedDate = parseTimeM False
                     defaultTimeLocale
                     (T.unpack wpFormat)
                     (T.unpack date) :: Maybe UTCTime in

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -63,14 +63,14 @@ wpCustomDateFill =
                                       (T.unpack wpFormat)
                                       (T.unpack date) :: Maybe UTCTime in
           case parsedDate of
-              Just d -> let dateSubs = subs [ ("wpYear", datePartFill "%0Y" d)
-                                            , ("wpMonth", datePartFill "%m" d)
-                                            , ("wpDay", datePartFill "%d" d)
-                                            , ("wpDate", datePartFill "%D" d) ] in
+              Just d -> let dateSubs = subs [ ("wpYear",     datePartFill "%0Y" d)
+                                            , ("wpMonth",    datePartFill "%m" d)
+                                            , ("wpDay",      datePartFill "%d" d)
+                                            , ("wpFullDate", datePartFill "%D" d) ] in
                         fillChildrenWith dateSubs
               Nothing -> textFill $ "<!-- Unable to parse date: " <> date <> " -->"
         datePartFill defaultFormat date =
-                useAttrs (a "format_out") $ \mf ->
+                useAttrs (a "format") $ \mf ->
                    let f = fromMaybe defaultFormat mf in
                    textFill $ T.pack $ formatTime defaultTimeLocale (T.unpack f) date
 


### PR DESCRIPTION
Simplify wpCustomDate as well.

Note that wpCustomDate has a different default date format than wpDate.