### PR TITLE
Fix compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## February 27 2017
+ * Add "PN" and "PM" for custom-parsed fields with objects and lists
+
 ## February 9 2017
 
  * Add "format" attribute to `wpDate` in `wpPosts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## February 27 2017
- * Add "PN" and "PM" for custom-parsed fields with objects and lists
-
 ## February 9 2017
 
  * Add "format" attribute to `wpDate` in `wpPosts`

--- a/offset.cabal
+++ b/offset.cabal
@@ -60,6 +60,20 @@ Test-Suite test-offset
     hs-source-dirs: spec, src
     main-is: Main.hs
     other-modules: Misc
+                 , Common
+                 , Web.Offset
+                 , Web.Offset.Cache
+                 , Web.Offset.Cache.Redis
+                 , Web.Offset.Cache.Types
+                 , Web.Offset.Field
+                 , Web.Offset.HTTP
+                 , Web.Offset.Init
+                 , Web.Offset.Internal
+                 , Web.Offset.Posts
+                 , Web.Offset.Queries
+                 , Web.Offset.Splices
+                 , Web.Offset.Types
+                 , Web.Offset.Utils
     build-depends:     base
                      , aeson
                      , async

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -71,6 +71,7 @@ article1 = object [ "id" .= (1 :: Int)
                   , "date" .= ("2014-10-20T07:00:00" :: Text)
                   , "title" .= object ["rendered" .= ("Foo bar" :: Text)]
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
+                  , "departments" .= [ object [ "name" .= ("some department" :: Text)]]
                   ]
 
 article2 = object [ "id" .= (2 :: Int)
@@ -90,7 +91,17 @@ customFields = [N "featured_image" [N "attachment_meta" [N "sizes" [N "mag-featu
                                                                                      ,F "url"]
                                                                    ,N "single-featured" [F "width"
                                                                                         ,F "height"
-                                                                                        ,F "url"]]]]]
+                                                                                        ,F "url"]]]]
+               ,PM "departments" departmentFill ]
+
+departmentFill :: [Object] -> Fill s
+departmentFill objs =
+  let singleText :: Object -> Text
+      singleText o = toStr $ HM.lookup "name" o
+      toStr (Just (String s)) = s
+      toStr _ = error "not a string" in
+  mapSubs (\x -> subs [("name", textFill x)])
+    (map singleText objs)
 
 tplLibrary :: Library Ctxt
 tplLibrary =
@@ -171,7 +182,7 @@ initializer requester cache endpoint =
      let wpconf = def { wpConfEndpoint = endpoint
                       , wpConfLogger = Nothing
                       , wpConfRequester = requester
-                      , wpConfExtraFields = []
+                      , wpConfExtraFields = customFields
                       , wpConfCacheBehavior = cache
                    }
      let getUri :: StateT Ctxt IO Text

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -57,7 +57,6 @@ article1 = object [ "id" .= (1 :: Int)
                   , "date" .= ("2014-10-20T07:00:00" :: Text)
                   , "title" .= object ["rendered" .= ("Foo bar" :: Text)]
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
-                  , "departments" .= [ object [ "name" .= ("some department" :: Text)]]
                   ]
 
 article2 :: Value
@@ -80,17 +79,7 @@ customFields = [N "featured_image" [N "attachment_meta" [N "sizes" [N "mag-featu
                                                                                      ,F "url"]
                                                                    ,N "single-featured" [F "width"
                                                                                         ,F "height"
-                                                                                        ,F "url"]]]]
-               ,PM "departments" departmentFill ]
-
-departmentFill :: [Object] -> Fill s
-departmentFill objs =
-  let singleText :: Object -> Text
-      singleText o = toStr $ HM.lookup "name" o
-      toStr (Just (String s)) = s
-      toStr _ = error "not a string" in
-  mapSubs (\x -> subs [("name", textFill x)])
-    (map singleText objs)
+                                                                                        ,F "url"]]]]]
 
 tplLibrary :: Library Ctxt
 tplLibrary =
@@ -172,7 +161,7 @@ initializer requester cache endpoint =
      let wpconf = def { wpConfEndpoint = endpoint
                       , wpConfLogger = Nothing
                       , wpConfRequester = requester
-                      , wpConfExtraFields = customFields
+                      , wpConfExtraFields = []
                       , wpConfCacheBehavior = cache
                    }
      let getUri :: StateT Ctxt IO Text

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -6,46 +6,31 @@
 
 module Common where
 
-import           Prelude                  hiding ((++))
-
-import           Blaze.ByteString.Builder
-import           Configuration.Dotenv     (loadFile)
-import           Control.Concurrent       (forkIO)
 import           Control.Concurrent.MVar
-import           Control.Exception        (throw)
-import           Control.Lens             hiding ((.=))
-import           Control.Monad            (mplus, void, when)
-import           Control.Monad.State      (StateT, evalStateT)
-import qualified Control.Monad.State      as S
-import           Control.Monad.Trans      (liftIO)
-import           Data.Aeson               hiding (Success)
+import           Control.Lens            hiding ((.=))
+import           Control.Monad           (void)
+import           Control.Monad.State     (StateT, evalStateT)
+import qualified Control.Monad.State     as S
+import           Control.Monad.Trans     (liftIO)
+import           Data.Aeson              hiding (Success)
 import           Data.Default
-import qualified Data.HashMap.Strict      as HM
-import qualified Data.Map                 as M
+import qualified Data.Map                as M
 import           Data.Maybe
 import           Data.Monoid
-import qualified Data.Set                 as Set
-import           Data.Text                (Text, pack, unpack)
-import qualified Data.Text                as T
-import qualified Data.Text.Encoding       as T
-import qualified Data.Text.Lazy           as TL
-import qualified Data.Text.Lazy.Encoding  as TL
-import qualified Database.Redis           as R
-import qualified Misc
-import           Network.Wai              (Application, Response,
-                                           defaultRequest, pathInfo,
-                                           rawPathInfo)
-import           System.Directory         (doesFileExist)
-import           System.Environment       (lookupEnv)
+import           Data.Text               (Text)
+import qualified Data.Text               as T
+import qualified Data.Text.Encoding      as T
+import qualified Data.Text.Lazy          as TL
+import qualified Data.Text.Lazy.Encoding as TL
+import qualified Database.Redis          as R
+import           Network.Wai             (defaultRequest, rawPathInfo)
+import           Prelude                 hiding ((++))
 import           Test.Hspec
-import           Test.Hspec.Core.Spec     (Result (..))
-import qualified Text.XmlHtml             as X
 import           Web.Fn
 import           Web.Larceny
 
 import           Web.Offset
 import           Web.Offset.Cache.Redis
-import           Web.Offset.Splices       (wpPostsHelper)
 import           Web.Offset.Types
 
 ----------------------------------------------------------
@@ -64,7 +49,8 @@ makeLenses ''Ctxt
 instance RequestContext Ctxt where
   requestLens = req
 
-enc a = TL.toStrict . TL.decodeUtf8 . encode $ a
+enc :: ToJSON r => r -> Text
+enc val = TL.toStrict . TL.decodeUtf8 . encode $ val
 
 article1 :: Value
 article1 = object [ "id" .= (1 :: Int)
@@ -73,18 +59,21 @@ article1 = object [ "id" .= (1 :: Int)
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
                   ]
 
+article2 :: Value
 article2 = object [ "id" .= (2 :: Int)
                   , "date" .= ("2014-10-20T07:00:00" :: Text)
                   , "title" .= object ["rendered" .= ("The post" :: Text)]
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
                   ]
 
+page1 :: Value
 page1 = object [ "id" .= (3 :: Int)
                , "date" .= ("2014-10-20T07:00:00" :: Text)
                , "title" .= object ["rendered" .= ("Page foo" :: Text)]
                , "content" .= object ["rendered" .= ("<b>rendered</b> page content" :: Text)]
                ]
 
+customFields :: [Field s]
 customFields = [N "featured_image" [N "attachment_meta" [N "sizes" [N "mag-featured" [F "width"
                                                                                      ,F "height"
                                                                                      ,F "url"]
@@ -166,6 +155,7 @@ fauxRequester mRecord rqPath rqParams = do
              url <> "?"
           <> T.intercalate "&" (map (\(k, v) -> k <> "=" <> v) params)
 
+initializer :: Either UserPassword Requester -> CacheBehavior -> Text -> IO Ctxt
 initializer requester cache endpoint =
   do rconn <- R.connect R.defaultConnectInfo
      let wpconf = def { wpConfEndpoint = endpoint
@@ -180,9 +170,11 @@ initializer requester cache endpoint =
      (wp,wpSubs) <- initWordpress wpconf rconn getUri wordpress
      return (Ctxt defaultFnRequest rconn wp wpSubs mempty)
 
+initFauxRequestNoCache :: IO Ctxt
 initFauxRequestNoCache =
   initializer (Right $ Requester (fauxRequester Nothing)) NoCache ""
 
+initNoRequestWithCache :: IO Ctxt
 initNoRequestWithCache =
   initializer (Right $ Requester (\_ _ -> return (Right "") )) (CacheSeconds 600) ""
 
@@ -203,8 +195,10 @@ unobj :: Value -> Object
 unobj (Object x) = x
 unobj _ = error "Not an object"
 
+toTpl :: Text -> Template s
 toTpl tpl = parse (TL.fromStrict tpl)
 
+ignoreWhitespace :: Text -> Text
 ignoreWhitespace = T.replace " " ""
 
 shouldRender :: TemplateText
@@ -218,20 +212,22 @@ shouldRender t output = do
 
 -- Caching helpers
 
-wpCacheGet' wordpress wpKey = do
-  let WordpressInt{..} = cacheInternals wordpress
+wpCacheGet' :: S.MonadIO m => Wordpress b -> WPKey -> m (Maybe Text)
+wpCacheGet' wordpress' wpKey = do
+  let WordpressInt{..} = cacheInternals wordpress'
   liftIO $ wpCacheGet wpKey
 
-wpCacheSet' wordpress wpKey o = do
-  let WordpressInt{..} = cacheInternals wordpress
+wpCacheSet' :: S.MonadIO m => Wordpress b -> WPKey -> Text -> m ()
+wpCacheSet' wordpress' wpKey o = do
+  let WordpressInt{..} = cacheInternals wordpress'
   liftIO $ wpCacheSet wpKey o
 
-wpExpireAggregates' wordpress = do
-  let Wordpress{..} = wordpress
+wpExpireAggregates' :: S.MonadIO m => Wordpress t -> m Bool
+wpExpireAggregates' Wordpress{..} =
   liftIO wpExpireAggregates
 
-wpExpirePost' wordpress k = do
-  let Wordpress{..} = wordpress
+wpExpirePost' :: S.MonadIO m => Wordpress t -> WPKey -> m Bool
+wpExpirePost'  Wordpress{..} k =
   liftIO $ wpExpirePost k
 
 {-
@@ -259,7 +255,7 @@ shouldQueryTo hQuery wpQuery =
                          NoCache
                          ""
       let s = _wpsubs ctxt
-      evalStateT (runTemplate (toTpl hQuery) [] s mempty) ctxt
+      void $ evalStateT (runTemplate (toTpl hQuery) [] s mempty) ctxt
       x <- liftIO $ tryTakeMVar record
       x `shouldBe` Just wpQuery
 
@@ -301,8 +297,7 @@ shouldRenderAtUrlContaining :: (TemplateName, Ctxt)
 shouldRenderAtUrlContaining (template, ctxt) (url, match) = do
     let requestWithUrl = defaultRequest {rawPathInfo = T.encodeUtf8 url }
     let ctxt' = setRequest ctxt
-                 $ (\(x,y) -> (requestWithUrl, y)) defaultFnRequest
-    let s = _wpsubs ctxt
+                 $ (\(_,x) -> (requestWithUrl, x)) defaultFnRequest
     rendered <- renderLarceny ctxt' template
     let rendered' = fromMaybe "" rendered
     (match `T.isInfixOf` rendered') `shouldBe` True

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -50,9 +50,6 @@ larcenyFillTests = do
       \    <wpMonth format=\"%B\"/> <wpDay format=\"%-d\"/>, <wpYear /> \
       \  </wpDate> \
       \</wpPosts>" `shouldRender` "October 20, 2014"
-    it "should render customly parsed fields" $
-      "<wpPosts><wpDepartments><name /></wpDepartments></wpPosts>"
-      `shouldRender` "some department"
   describe "<wpPage>" $
     it "should show the content" $
       "<wpPage name=a-first-page />" `shouldRender` "<b>rendered</b> page content"

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -69,6 +69,9 @@ larcenyFillTests = do
       \    <wpMonth format=\"%B\"/> <wpDay format=\"%-d\"/>, <wpYear /> \
       \  </wpDate> \
       \</wpPosts>" `shouldRender` "October 20, 2014"
+    it "should render customly parsed fields" $
+      "<wpPosts><wpDepartments><name /></wpDepartments></wpPosts>"
+      `shouldRender` "some department"
   describe "<wpPage>" $
     it "should show the content" $
       "<wpPage name=a-first-page />" `shouldRender` "<b>rendered</b> page content"

--- a/spec/Misc.hs
+++ b/spec/Misc.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
 
 module Misc where
 
@@ -14,14 +13,7 @@ shouldTransformTo :: Text -> Text -> Spec
 shouldTransformTo from to =
   it (T.unpack ("should convert " <> from <> " to " <> to)) $ transformName from `shouldBe` to
 
--- NOTE(dbp 2014-11-07): We define equality that is 'good enough' for testing.
--- In truth, our definition is wrong because of the functions inside of 'P' variants.
-instance Eq (Field s) where
-  F t1 == F t2 = t1 == t2
-  P t1 _ == P t2 _ = t1 == t2
-  N t1 n1 == N t2 n2 = t1 == t2 && n1 == n2
-  M t1 m1 == M t2 m2 = t1 == t2 && m1 == m2
-
+tests :: Spec
 tests = do
   describe "mergeFields" $ do
     it "should be able to right-bias merge two Field trees" $

--- a/src/Web/Offset/Cache.hs
+++ b/src/Web/Offset/Cache.hs
@@ -4,18 +4,16 @@
 
 module Web.Offset.Cache where
 
-import           Control.Concurrent       as CC
-import qualified Control.Concurrent.Async as CC
-import           Control.Concurrent.MVar
-import           Control.Monad            (void)
-import           Data.Map                 (Map)
-import qualified Data.Map                 as Map
-import           Data.Monoid              ((<>))
-import qualified Data.Set                 as Set
-import           Data.Text                (Text)
-import qualified Data.Text                as T
-import           Data.Time.Clock          (UTCTime, diffUTCTime, getCurrentTime)
-import           Database.Redis           (Redis)
+import           Control.Concurrent     as CC
+import           Control.Monad          (void)
+import           Data.Map               (Map)
+import qualified Data.Map               as Map
+import           Data.Monoid            ((<>))
+import qualified Data.Set               as Set
+import           Data.Text              (Text)
+import qualified Data.Text              as T
+import           Data.Time.Clock        (UTCTime, diffUTCTime, getCurrentTime)
+import           Database.Redis         (Redis)
 
 import           Web.Offset.Cache.Redis
 import           Web.Offset.Cache.Types
@@ -53,7 +51,7 @@ retryUnless action =
                    retryUnless action
 
 errorUnless :: Text -> IO (CacheResult a) -> IO (Either StatusCode a)
-errorUnless msg action =
+errorUnless _ action =
   do ma <- action
      case ma of
       Successful a -> return $ Right a

--- a/src/Web/Offset/Cache/Redis.hs
+++ b/src/Web/Offset/Cache/Redis.hs
@@ -1,12 +1,11 @@
 module Web.Offset.Cache.Redis where
 
-import           Control.Applicative ((<$>))
-import           Control.Monad       (join)
-import           Data.Either         (isRight)
-import           Data.Text           (Text)
-import qualified Data.Text.Encoding  as T
-import           Database.Redis      (Redis)
-import qualified Database.Redis      as R
+import           Control.Monad      (join)
+import           Data.Either        (isRight)
+import           Data.Text          (Text)
+import qualified Data.Text.Encoding as T
+import           Database.Redis     (Redis)
+import qualified Database.Redis     as R
 
 rsetex :: Text -> Int -> Text -> Redis Bool
 rsetex k n v = isRight <$> R.setex (T.encodeUtf8 k) (toInteger n) (T.encodeUtf8 v)

--- a/src/Web/Offset/Field.hs
+++ b/src/Web/Offset/Field.hs
@@ -3,21 +3,16 @@
 
 module Web.Offset.Field where
 
-import           Control.Applicative ((<$>))
-import           Control.Monad.State
-import           Data.Aeson          (Object)
-import           Data.Maybe          (fromMaybe)
-import           Data.Monoid         ((<>))
-import           Data.Text           (Text)
-import qualified Data.Text           as T
-import           Data.Time.Clock     (UTCTime)
-import           Data.Time.Format    (defaultTimeLocale, formatTime, parseTimeM)
+import           Data.Maybe       (fromMaybe)
+import           Data.Monoid      ((<>))
+import           Data.Text        (Text)
+import qualified Data.Text        as T
+import           Data.Time.Clock  (UTCTime)
+import           Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import           Web.Larceny
 
 data Field s = F Text -- A single flat field
              | P Text (Text -> Fill s) -- A customly parsed flat field
-             | PN Text (Object -> Fill s) -- A customly parsed nested field
-             | PM Text ([Object] -> Fill s) -- A customly parsed list field
              | N Text [Field s] -- A nested object field
              | C Text [Text] -- A nested text field that is found by following the specified path
              | CN Text [Text] [Field s] -- A nested set of fields that is found by follwing the specified path
@@ -47,8 +42,6 @@ mergeFields fo (f:fs) = mergeFields (overrideInList False f fo) fs
         matchesName c d = getName c == getName d
         getName (F t) = t
         getName (P t _) = t
-        getName (PN t _) = t
-        getName (PM t _) = t
         getName (N t _) = t
         getName (C t _) = t
         getName (CN t _ _) = t

--- a/src/Web/Offset/Field.hs
+++ b/src/Web/Offset/Field.hs
@@ -6,6 +6,7 @@ module Web.Offset.Field where
 import           Control.Applicative ((<$>))
 import           Control.Monad.State
 import           Data.Maybe          (fromMaybe)
+import           Data.Aeson          (Object)
 import           Data.Monoid         ((<>))
 import           Data.Text           (Text)
 import qualified Data.Text           as T
@@ -16,6 +17,8 @@ import           Web.Larceny
 -- TODO(dbp 2014-10-14): date should be parsed and nested.
 data Field s = F Text -- A single flat field
              | P Text (Text -> Fill s) -- A customly parsed flat field
+             | PN Text (Object -> Fill s) -- A customly parsed nested field
+             | PM Text ([Object] -> Fill s) -- A customly parsed list field
              | N Text [Field s] -- A nested object field
              | C Text [Text] -- A nested text field that is found by following the specified path
              | CN Text [Text] [Field s] -- A nested set of fields that is found by follwing the specified path
@@ -33,6 +36,8 @@ mergeFields fo (f:fs) = mergeFields (overrideInList False f fo) fs
         matchesName a b = getName a == getName b
         getName (F t) = t
         getName (P t _) = t
+        getName (PN t _) = t
+        getName (PM t _) = t
         getName (N t _) = t
         getName (C t _) = t
         getName (CN t _ _) = t

--- a/src/Web/Offset/Init.hs
+++ b/src/Web/Offset/Init.hs
@@ -4,31 +4,17 @@
 module Web.Offset.Init where
 
 import           Control.Concurrent.MVar
-import           Control.Lens            hiding (children)
 import           Control.Monad.State
-import           Control.Monad.Trans     (liftIO)
-import qualified Data.Configurator       as C
-import           Data.Default
 import qualified Data.Map                as Map
-import           Data.Monoid
 import           Data.Text               (Text)
 import qualified Database.Redis          as R
 import           Web.Larceny
 
 import           Web.Offset.Cache
-import           Web.Offset.Cache.Types
 import           Web.Offset.HTTP
 import           Web.Offset.Internal
 import           Web.Offset.Splices
 import           Web.Offset.Types
-
-
-instance Default (WordpressConfig m) where
-  def = WordpressConfig "http://127.0.0.1:8080/wp-json"
-                        (Left ("offset", "111"))
-                        (CacheSeconds 600)
-                        []
-                        Nothing
 
 initWordpress :: WordpressConfig s
               -> R.Connection

--- a/src/Web/Offset/Internal.hs
+++ b/src/Web/Offset/Internal.hs
@@ -34,11 +34,12 @@ wpRequestInt runHTTP endpt key =
 buildParams :: WPKey -> [(Text, Text)]
 buildParams (PostsKey filters) = params
   where params = Set.toList $ Set.map mkFilter filters
-        mkFilter (TaxFilter taxName (TaxPlusId i)) = (taxName <> "[]", tshow i)
-        mkFilter (TaxFilter taxName (TaxMinusId i)) = (taxName <> "_exclude[]", tshow i)
+        mkFilter (TaxFilter taxonomyName (TaxPlusId i)) = (taxonomyName <> "[]", tshow i)
+        mkFilter (TaxFilter taxonomyName (TaxMinusId i)) = (taxonomyName <> "_exclude[]", tshow i)
         mkFilter (NumFilter num) = ("per_page", tshow num)
         mkFilter (OffsetFilter offset) = ("offset", tshow offset)
         mkFilter (UserFilter user) = ("author[]", user)
+buildParams _ = []
 
 wpLogInt :: Maybe (Text -> IO ()) -> Text -> IO ()
 wpLogInt logger msg = case logger of

--- a/src/Web/Offset/Queries.hs
+++ b/src/Web/Offset/Queries.hs
@@ -24,13 +24,13 @@ getSpecId taxDict spec =
        (TaxRes (i,_):_) -> i
 
 lookupSpecId :: Wordpress b -> TaxonomyName -> TaxSpec -> IO (Maybe TaxSpecId)
-lookupSpecId wp@Wordpress{..} taxName spec =
+lookupSpecId Wordpress{..} taxName spec =
   case spec of
    TaxPlus slug -> (fmap . fmap) (\(TaxRes (i, _)) -> TaxPlusId i) (idFor taxName slug)
    TaxMinus slug -> (fmap . fmap) (\(TaxRes (i, _)) -> TaxMinusId i) (idFor taxName slug)
   where
     idFor :: Text -> Text -> IO (Maybe TaxRes)
-    idFor taxName slug = do
+    idFor _ slug = do
       let key = TaxSlugKey taxName slug
       let cacheSettings = cacheInternals { wpCacheSet = wpCacheSetInt (runRedis cacheInternals)
                                                                       (CacheSeconds (12 * 60 * 60)) }
@@ -47,7 +47,7 @@ lookupSpecId wp@Wordpress{..} taxName spec =
           wpLogger $ "No id found in lookupSpecId for: " <> tshow spec
           return Nothing
         Right (Just [taxRes]) -> return $ Just taxRes
-        Right (Just (x:xs)) ->  do
+        Right (Just (_:_)) ->  do
           wpLogger $ "JSON response in lookupSpecId for: " <> tshow spec
                      <> " contains multiple results: " <> tshow resp
           return Nothing

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -53,22 +53,10 @@ wpCustomDateFill :: Fill s
 wpCustomDateFill =
   useAttrs (a "wp_format" % a "date") customDateFill
   where customDateFill mWPFormat date =
-          let wpFormat = fromMaybe "%Y-%m-%d %H:%M:%S" mWPFormat
-              parsedDate = parseTimeM False
-                                      defaultTimeLocale
-                                      (T.unpack wpFormat)
-                                      (T.unpack date) :: Maybe UTCTime in
-          case parsedDate of
-              Just d -> let dateSubs = subs [ ("wpYear",     datePartFill "%0Y" d)
-                                            , ("wpMonth",    datePartFill "%m" d)
-                                            , ("wpDay",      datePartFill "%d" d)
-                                            , ("wpFullDate", datePartFill "%D" d) ] in
-                        fillChildrenWith dateSubs
+          let wpFormat = fromMaybe "%Y-%m-%d %H:%M:%S" mWPFormat in
+          case parseWPDate wpFormat date of
+              Just d -> fillChildrenWith $ datePartSubs d
               Nothing -> textFill $ "<!-- Unable to parse date: " <> date <> " -->"
-        datePartFill defaultFormat date =
-                useAttrs (a "format") $ \mf ->
-                   let f = fromMaybe defaultFormat mf in
-                   textFill $ T.pack $ formatTime defaultTimeLocale (T.unpack f) date
 
 wpCustomFill :: Wordpress b -> Fill s
 wpCustomFill Wordpress{..} =

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -182,10 +182,6 @@ postSubs extra object = subs (map (buildSplice object) (mergeFields postFields e
           (transformName n, textFill $ getText n o)
         buildSplice o (P n fill') =
           (transformName n, fill' $ getText n o)
-        buildSplice o (PN n fill') =
-          (transformName n, fill' (unObj . M.lookup n $ o))
-        buildSplice o (PM n fill') =
-          (transformName n, fill' (unArray . M.lookup n $ o))
         buildSplice o (N n fs) =
           (transformName n, fillChildrenWith $ subs
                             (map (buildSplice (unObj . M.lookup n $ o)) fs))

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -199,6 +199,10 @@ postSubs extra object = subs (map (buildSplice object) (mergeFields postFields e
           (transformName n, textFill $ getText n o)
         buildSplice o (P n fill') =
           (transformName n, fill' $ getText n o)
+        buildSplice o (PN n fill') =
+          (transformName n, fill' (unObj . M.lookup n $ o))
+        buildSplice o (PM n fill') =
+          (transformName n, fill' (unArray . M.lookup n $ o))
         buildSplice o (N n fs) =
           (transformName n, fillChildrenWith $ subs
                             (map (buildSplice (unObj . M.lookup n $ o)) fs))

--- a/src/Web/Offset/Types.hs
+++ b/src/Web/Offset/Types.hs
@@ -12,10 +12,9 @@
 module Web.Offset.Types where
 
 import           Control.Lens           hiding (children)
-import           Control.Monad          (mzero)
 import           Control.Monad.State
 import           Data.Aeson             (FromJSON, Value (..), parseJSON, (.:))
-import qualified Data.HashMap.Strict    as M
+import           Data.Default
 import           Data.IntSet            (IntSet)
 import           Data.List              (intercalate)
 import           Data.Maybe             (catMaybes, isJust)
@@ -51,6 +50,13 @@ data WordpressConfig m =
                      , wpConfExtraFields   :: [Field m]
                      , wpConfLogger        :: Maybe (Text -> IO ())
                      }
+
+instance Default (WordpressConfig m) where
+  def = WordpressConfig "http://127.0.0.1:8080/wp-json"
+                        (Left ("offset", "111"))
+                        (CacheSeconds 600)
+                        []
+                        Nothing
 
 data WordpressInt b =
      WordpressInt { wpCacheGet    :: WPKey -> IO (Maybe Text)

--- a/src/Web/Offset/Utils.hs
+++ b/src/Web/Offset/Utils.hs
@@ -2,12 +2,10 @@
 
 module Web.Offset.Utils where
 
-import           Control.Concurrent       as CC
 import qualified Control.Concurrent.Async as CC
 import           Data.Aeson               (FromJSON, ToJSON)
 import qualified Data.Aeson               as J
 import           Data.Maybe
-import           Data.Monoid
 import           Data.Text                (Text)
 import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as T


### PR DESCRIPTION
Removed a lot of unused imports, shadowing, added `void` for unused `do` binds, etc.