### PR TITLE
Users can create fields that query an endpoint

### DIFF
--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -59,6 +59,7 @@ article1 = object [ "id" .= (1 :: Int)
                   , "title" .= object ["rendered" .= ("<i>Foo</i> bar" :: Text)]
                   , "excerpt" .= object ["rendered" .= ("summary" :: Text)]
                   , "departments" .= [ object [ "name" .= ("some department" :: Text)]]
+                  , "department" .= ("15" :: Text)
                   ]
 
 article2 :: Value
@@ -73,16 +74,28 @@ page1 = object [ "id" .= (3 :: Int)
                , "date" .= ("2014-10-20T07:00:00" :: Text)
                , "title" .= object ["rendered" .= ("Page foo" :: Text)]
                , "content" .= object ["rendered" .= ("<b>rendered</b> page content" :: Text)]
+               , "department" .= ("15" :: Text)
                ]
 
+department :: Value
+department = object [ "id" .= (2 :: Int)
+                    , "slug" .= ("2014-10-20T07:00:00" :: Text)
+                    , "name" .= ("Sports" :: Text)
+                    ]
+
 customFields :: [Field s]
-customFields = [N "featured_image" [N "attachment_meta" [N "sizes" [N "mag-featured" [F "width"
-                                                                                     ,F "height"
-                                                                                     ,F "url"]
-                                                                   ,N "single-featured" [F "width"
-                                                                                        ,F "height"
-                                                                                        ,F "url"]]]]
-               ,PM "departments" departmentFill ]
+customFields = [N "featured_image"
+                 [N "attachment_meta"
+                   [N "sizes"
+                     [N "mag-featured"
+                       [F "width"
+                       ,F "height"
+                       ,F "url"]
+                     ,N "single-featured" [F "width"
+                                          ,F "height"
+                                          ,F "url"]]]]
+               ,PM "departments" departmentFill
+               ,Q "department" (UseId "/wp/v2/department/") ]
 
 departmentFill :: [Object] -> Fill s
 departmentFill objs =
@@ -149,6 +162,8 @@ fauxRequester _ "/wp/v2/categories" [("slug", "bookmarx")] =
                        , "slug" .= ("bookmarx" :: Text)
                        , "meta" .= object ["links" .= object ["self" .= ("/159" :: Text)]]
                        ] ]
+fauxRequester _ "//wp/v2/department/15" [] =
+  return $ Right $ enc department
 fauxRequester _ "/jacobin/featured-content/editors-picks" [] =
   return $ Right $ enc [object [ "post_date" .= ("2013-04-26 10:11:52" :: Text)
                        , "date" .= ("2014-04-26 10:11:52" :: Text)

--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -89,6 +89,18 @@ larcenyFillTests = do
       rendered <- evalStateT (runTemplate tpl [] s mempty) ctxt'
       rendered `shouldBe` "<i>Foo</i> bar"
 
+  describe "extra request fields" $ do
+
+    it "should render stuff" $ do
+      ctxt <- initFauxRequestNoCache
+      let requestWithUrl = defaultRequest {rawPathInfo = T.encodeUtf8 "/2009/10/the-post/"}
+      let ctxt' = setRequest ctxt
+                 $ (\(_,y) -> (requestWithUrl, y)) defaultFnRequest
+      let s = view wpsubs ctxt'
+      let tpl = toTpl "<wp><wpPostByPermalink><wpDepartment><wpName /></wpDepartment></wp>"
+      rendered <- evalStateT (runTemplate tpl [] s mempty) ctxt'
+      rendered `shouldBe` "Sports"
+
   describe "<wpCustom>" $
     it "should render an HTML comment if JSON field is null" $
       "<wpCustom endpoint=\"dev/null\"><wpThisIsNull /></wpCustom>" `shouldRender` "<!-- JSON field found, but value is null. -->"

--- a/src/Web/Offset.hs
+++ b/src/Web/Offset.hs
@@ -24,6 +24,7 @@ module Web.Offset (
  , CatType
  , TaxSpecList(..)
  , Field(..)
+ , ToEndpoint(..)
  , mergeFields
  , attrToTaxSpecList
  ) where

--- a/src/Web/Offset/Splices.hs
+++ b/src/Web/Offset/Splices.hs
@@ -34,10 +34,10 @@ import           Web.Offset.Types
 import           Web.Offset.Utils
 
 wordpressSubs ::   Wordpress b
-                 -> [Field s]
-                 -> StateT s IO Text
-                 -> WPLens b s
-                 -> Substitutions s
+              -> [Field s]
+              -> StateT s IO Text
+              -> WPLens b s
+              -> Substitutions s
 wordpressSubs wp extraFields getURI wpLens =
   subs [ ("wpPosts", wpPostsFill wp extraFields wpLens)
        , ("wpPostByPermalink", wpPostByPermalinkFill extraFields getURI wpLens)
@@ -45,7 +45,7 @@ wordpressSubs wp extraFields getURI wpLens =
        , ("wpNoPostDuplicates", wpNoPostDuplicatesFill wpLens)
        , ("wp", wpPrefetch wp extraFields getURI wpLens)
        , ("wpCustom", wpCustomFill wp)
-       , ("wpCustomDate", wpCustomDateFill)]
+       , ("wpCustomDate", wpCustomDateFill) ]
 
 wpCustomDateFill :: Fill s
 wpCustomDateFill =
@@ -57,23 +57,25 @@ wpCustomDateFill =
               Nothing -> rawTextFill $ "<!-- Unable to parse date: " <> date <> " -->"
 
 wpCustomFill :: Wordpress b -> Fill s
-wpCustomFill Wordpress{..} =
-  useAttrs (a "endpoint") customFill
-  where customFill endpoint = Fill $ \attrs (path, tpl) lib ->
-          do let key = EndpointKey endpoint
-             res <- liftIO $ cachingGetRetry key
-             case fmap decode res of
-               Left code -> do
-                 let notification = "Encountered status code " <> tshow code
-                                   <> " when querying \"" <> endpoint <> "\"."
-                 liftIO $ wpLogger notification
-                 return $ "<!-- " <> notification <> " -->"
-               Right (Just (json :: Value)) ->
-                 unFill (jsonToFill json) attrs (path, tpl) lib
-               Right Nothing -> do
-                 let notification = "Unable to decode JSON for endpoint \"" <> endpoint
-                 liftIO $ wpLogger $ notification <> ": " <> tshow res
-                 return $ "<!-- " <> notification <> "-->"
+wpCustomFill wp =
+  useAttrs (a "endpoint") (customFill wp)
+
+customFill :: Wordpress b -> Text -> Fill s
+customFill Wordpress{..} endpoint = Fill $ \attrs (path, tpl) lib ->
+  do let key = EndpointKey endpoint
+     res <- liftIO $ cachingGetRetry key
+     case fmap decode res of
+       Left code -> do
+         let notification = "Encountered status code " <> tshow code
+                         <> " when querying \"" <> endpoint <> "\"."
+         liftIO $ wpLogger notification
+         return $ "<!-- " <> notification <> " -->"
+       Right (Just (json :: Value)) ->
+         unFill (jsonToFill json) attrs (path, tpl) lib
+       Right Nothing -> do
+         let notification = "Unable to decode JSON for endpoint \"" <> endpoint
+         liftIO $ wpLogger $ notification <> ": " <> tshow res
+         return $ "<!-- " <> notification <> "-->"
 
 jsonToFill :: Value -> Fill s
 jsonToFill (Object o) =
@@ -109,7 +111,7 @@ wpPostsFill wp extraFields wpLens = Fill $ \attrs tpl lib ->
          let postsND = take (qlimit postsQuery)
                        . noDuplicates (requestPostSet wp') $ postsW
          addPostIds wpLens (map fst postsND)
-         unFill (wpPostsHelper extraFields (map snd postsND)) mempty tpl lib
+         unFill (wpPostsHelper wp extraFields (map snd postsND)) mempty tpl lib
        Right Nothing -> return ""
        Left code -> do
          let notification = "Encountered status code " <> tshow code
@@ -130,10 +132,12 @@ mkFilters wp specLists =
             Just tSpecId -> return $ Just (TaxFilter tName tSpecId)
             Nothing -> return Nothing
 
-wpPostsHelper :: [Field s]
+wpPostsHelper :: Wordpress b
+              -> [Field s]
               -> [Object]
               -> Fill s
-wpPostsHelper extraFields postsND = mapSubs (postSubs extraFields) postsND
+wpPostsHelper wp extraFields postsND =
+  mapSubs (postSubs wp extraFields) postsND
 
 wpPostByPermalinkFill :: [Field s]
                       -> StateT s IO Text
@@ -148,7 +152,8 @@ wpPostByPermalinkFill extraFields getURI wpLens = maybeFillChildrenWith' $
          do res <- wpGetPost wpLens (PostByPermalinkKey year month slug)
             case res of
               Just post -> do addPostIds wpLens [fst (extractPostId post)]
-                              return $ Just (postSubs extraFields post)
+                              wp <- use wpLens
+                              return $ Just (postSubs wp extraFields post)
               _ -> return Nothing
 
 wpNoPostDuplicatesFill :: WPLens b s -> Fill s
@@ -174,10 +179,12 @@ wpPageFill wpLens =
                                       _ -> ""
                        _ -> ""
 
-postSubs :: [Field s] -> Object -> Substitutions s
-postSubs extra object = subs (map (buildSplice object) (mergeFields postFields extra))
+postSubs :: Wordpress b -> [Field s] -> Object -> Substitutions s
+postSubs wp extra object = subs (map (buildSplice object) (mergeFields postFields extra))
   where buildSplice o (F n) =
           (transformName n, rawTextFill $ getText n o)
+        buildSplice o (Q n endpoint) =
+          (transformName n, customFill wp (toEndpoint endpoint $ getText n o))
         buildSplice o (P n fill') =
           (transformName n, fill' $ getText n o)
         buildSplice o (PN n fill') =


### PR DESCRIPTION
Rendering this field triggers a query to another endpoint and allows you to use all the fields from that endpoint.

We think this could lead to smaller and faster JSON responses and perhaps easier cache invalidation of custom post types.