### PR TITLE
Allow Feeds to specify how to get authors of posts

### DIFF
--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -41,7 +41,7 @@ main = runTests
 
 feedTests :: Spec
 feedTests =
-  describe "rss feed" $
+  describe "rss feed" $ do
     it "should make a feed" $ do
       ctxt <- initFauxRequestNoCache
       let wpfeed = WPFeed
@@ -51,6 +51,7 @@ feedTests =
                      Nothing
                      "https://myurl.com"
                      buildEntryLinks
+                     GuestAuthors
                      (renderFeedContent ctxt)
       ft <- toXMLFeed (_wordpress ctxt) wpfeed
       ft `shouldBe` "<?xml version='1.0' ?>\n<feed xmlns=\"http://www.w3.org/2005/Atom\">\n  <id>https://myurl.com/feed</id>\n  <title type=\"text\">My Blog</title>\n  <updated>2014-10-20T07:00:00Z</updated>\n  <entry>\n    <id>https://myurl.com/2014/10/foo-bar/</id>\n    <title type=\"html\">&lt;i&gt;Foo&lt;/i&gt; bar</title>\n    <updated>2014-10-20T07:00:00Z</updated>\n    <published>2014-10-20T07:00:00Z</published>\n    <summary type=\"html\">summary</summary>\n    <content type=\"html\">This is the title: &lt;i&gt;Foo&lt;/i&gt; bar</content>\n    <author>\n      <name>Emma Goldman</name>\n    </author>\n    <link href=\"https://myurl.com/2014/10/foo-bar/\" title=\"&lt;i&gt;Foo&lt;/i&gt; bar\" />\n  </entry>\n</feed>\n"

--- a/src/Web/Offset.hs
+++ b/src/Web/Offset.hs
@@ -30,15 +30,16 @@ module Web.Offset (
  , feedSubs
  , toXMLFeed
  , WPFeed(..)
+ , WPAuthorStyle(..)
  , Link(..)
  , buildPermalink
  ) where
 
 import           Web.Offset.Cache.Types
+import           Web.Offset.Feed
 import           Web.Offset.Field
 import           Web.Offset.HTTP
 import           Web.Offset.Init
-import           Web.Offset.Splices
-import           Web.Offset.Feed
 import           Web.Offset.Link
+import           Web.Offset.Splices
 import           Web.Offset.Types

--- a/src/Web/Offset/Feed.hs
+++ b/src/Web/Offset/Feed.hs
@@ -7,6 +7,8 @@ module Web.Offset.Feed where
 
 import           Control.Monad.State
 import           Data.Aeson          hiding (decode, encode, json, object)
+import           Data.Aeson.Types    (parseMaybe)
+import           Data.Maybe          (maybeToList)
 import           Data.Monoid
 import qualified Data.Text           as T
 import           Data.Time.Clock
@@ -27,13 +29,16 @@ data WPFeed =
          , wpFeedLogo    :: Maybe T.Text
          , wpBaseURI     :: T.Text
          , wpBuildLinks  :: Object -> [Link]
+         , wpGetAuthors  :: WPAuthorStyle
          , wpRenderEntry :: Object -> IO (Maybe T.Text) }
 
+data WPAuthorStyle = GuestAuthors | DefaultAuthor
+
 toXMLFeed :: Wordpress b -> WPFeed -> IO T.Text
-toXMLFeed wp wpFeed@(WPFeed uri title icon logo _ _ _) = do
+toXMLFeed wp wpFeed@(WPFeed uri title icon logo _ _ _ _) = do
   wpEntries <- getWPEntries wp
   let mostRecentUpdate = maximum (map wpEntryUpdated wpEntries)
-  entries <- mapM (toEntry wpFeed) wpEntries
+  entries <- mapM (toEntry wp wpFeed) wpEntries
   let feed = (makeFeed (unsafeURI $ T.unpack uri) (TextPlain title) mostRecentUpdate)
              { feedIcon = unsafeURI <$> T.unpack <$> icon
              , feedLogo = unsafeURI <$> T.unpack <$> logo
@@ -79,17 +84,21 @@ wpEntryContent :: (Object -> IO (Maybe T.Text))
 wpEntryContent renderer wpentry =
   (fmap . fmap) InlineHTMLContent (renderer $ wpEntryJSON wpentry)
 
-toEntry :: WPFeed
+toEntry :: Wordpress b
+        -> WPFeed
         -> WPEntry
         -> IO (Entry e)
-toEntry wpFeed entry@WPEntry{..} = do
+toEntry wp wpFeed entry@WPEntry{..} = do
   content <- wpEntryContent (wpRenderEntry wpFeed) entry
   let guid = entryGuid (wpBaseURI wpFeed) wpEntryId wpEntryJSON
   let baseEntry = makeEntry guid (TextHTML wpEntryTitle) wpEntryUpdated
+  authors <- case wpGetAuthors wpFeed of
+               GuestAuthors -> getAuthorsInline wpEntryJSON
+               DefaultAuthor -> getAuthorViaReq wp wpEntryJSON
   return $ baseEntry { entryPublished = Just wpEntryPublished
                      , entrySummary = Just (TextHTML wpEntrySummary)
                      , entryContent = content
-                     , entryAuthors = map unWP wpEntryAuthors
+                     , entryAuthors = map unWP authors
                      , entryLinks = map toAtomLink (wpBuildLinks wpFeed wpEntryJSON)}
 
 toAtomLink :: Link -> A.Link
@@ -107,7 +116,6 @@ data WPEntry =
           , wpEntryUpdated   :: UTCTime
           , wpEntryPublished :: UTCTime
           , wpEntrySummary   :: T.Text
-          , wpEntryAuthors   :: [WPPerson]
           , wpEntryJSON      :: Object } deriving (Eq, Show)
 
 instance FromJSON WPEntry where
@@ -119,7 +127,6 @@ instance FromJSON WPEntry where
                 (jsonParseDate <$> (v .: "date")) <*>
                 (do e <- v .: "excerpt"
                     e .: "rendered") <*>
-                v .: "authors" <*>
                 return v
   parseJSON _ = error "bad post"
 
@@ -129,6 +136,28 @@ instance FromJSON WPPerson where
   parseJSON (Object v) =
     WPPerson <$> (Person <$> v .: "name" <*> return Nothing <*> return Nothing)
   parseJSON _ = error "bad author"
+
+getAuthorsInline :: Object -> IO [WPPerson]
+getAuthorsInline v =
+  do let authors = parseMaybe (\obj -> obj .: "authors") v
+     case authors of
+       Just list -> return list
+       Nothing   -> return []
+
+getAuthorViaReq :: Wordpress b -> Object -> IO [WPPerson]
+getAuthorViaReq wp v =
+  do let mAuthorId = parseMaybe (\obj -> obj .: "author") v
+     case mAuthorId of
+       Nothing -> return []
+       Just authorId ->
+         do eRespError <- cachingGetRetry wp (EndpointKey $ "/wp/v2/author/" <> authorId)
+            case eRespError of
+              Left _ -> return []
+              Right resp ->
+                let mAuthorName = decodeJson resp >>= parseMaybe (\obj -> obj .: "name") in
+                  case mAuthorName of
+                    Nothing -> return []
+                    Just authorName ->return (maybeToList authorName)
 
 entryGuid :: T.Text -> Int -> Object -> URI
 entryGuid baseURI wpId wpJSON =


### PR DESCRIPTION
Feeds specify a WPAuthorStyle to say if they are using inline guest authors or
the default author-user style.